### PR TITLE
Add soft deletes

### DIFF
--- a/src/TheraPay.Core/BillingService.cs
+++ b/src/TheraPay.Core/BillingService.cs
@@ -134,6 +134,18 @@ public class BillingService
         return _invoiceRepository.GetAll();
     }
 
+    public Result DeleteDraftInvoice(Guid invoiceId)
+    {
+        if (_invoiceRepository.GetIndexById(invoiceId) < 0)
+            return new Result(false, $"Invoice with ID {invoiceId:D} not found.");
+
+        var invoice = _invoiceRepository.GetById(invoiceId);
+        if (invoice.Status != InvoiceStatus.Draft)
+            return new Result(false, "Nur Draft-Rechnungen können gelöscht werden.");
+
+        return _invoiceRepository.RemoveById(invoiceId);
+    }
+
     private Result ValidateInvoiceAppointmentsAreBillable(Invoice invoice)
     {
         var unavailableAppointments = new List<string>();

--- a/src/TheraPay.Core/PatientService.cs
+++ b/src/TheraPay.Core/PatientService.cs
@@ -160,7 +160,11 @@ public class PatientService
     {
         string trimmedId = id.Trim();
         int index = _repository.GetIndexById(trimmedId);
-        return index >= 0 ? _repository.GetByIndex(index) : null;
+        if (index < 0)
+            return null;
+
+        Patient patient = _repository.GetByIndex(index);
+        return patient.IsDeleted ? null : patient;
     }
 
     public Result UpdatePatient(
@@ -207,6 +211,19 @@ public class PatientService
             isActive,
             salutation,
             dateOfBirth);
+    }
+
+    public Result SoftDeletePatient(string id)
+    {
+        string trimmedId = id.Trim();
+        int index = _repository.GetIndexById(trimmedId);
+        if (index < 0)
+            return new Result(false, $"Patienten-ID '{trimmedId}' wurde nicht gefunden.");
+
+        Patient patient = _repository.GetByIndex(index);
+        patient.IsDeleted = true;
+        patient.IsActive = false;
+        return new Result(true);
     }
 
     public void ModifyAddress(
@@ -394,6 +411,8 @@ public class PatientService
 
     public IReadOnlyList<Patient> ViewPatients()
     {
-        return _repository.GetAll();
+        return _repository.GetAll()
+            .Where(patient => patient.IsDeleted == false)
+            .ToList();
     }
 }

--- a/src/TheraPay.Domain/Patient.cs
+++ b/src/TheraPay.Domain/Patient.cs
@@ -17,6 +17,7 @@ public class Patient
     public string Salutation { get; private set; } = "";
     public DateOnly? DateOfBirth { get; private set; }
     public bool IsActive { get; set; } = true;
+    public bool IsDeleted { get; set; }
     public Address? Address { get; private set; }
     public PatientInsuranceStatus InsuranceStatus { get; private set; } = PatientInsuranceStatus.Privat;
     public string ICD10Diagnosis { get; private set; } = "";

--- a/src/TheraPay.Infrastructure/csv/CsvPatientStore.cs
+++ b/src/TheraPay.Infrastructure/csv/CsvPatientStore.cs
@@ -35,6 +35,7 @@ public class CsvPatientStore(string filePath) : CsvStore<Patient, PatientCsvReco
             Email = patient.Email,
             PhoneNumber = patient.PhoneNumber,
             AdditionalInfo = patient.Address?.Additional ?? "",
+            IsActive = patient.IsActive,
         };
     }
 
@@ -57,6 +58,7 @@ public class CsvPatientStore(string filePath) : CsvStore<Patient, PatientCsvReco
             patient.SetPhoneNumber(record.PhoneNumber);
         if (TryParseInsuranceStatus(record.InsuranceStatus, out var insuranceStatus))
             patient.SetInsuranceStatus(insuranceStatus);
+        patient.IsActive = record.IsActive;
 
         return patient;
     }

--- a/src/TheraPay.Infrastructure/csv/CsvPatientStore.cs
+++ b/src/TheraPay.Infrastructure/csv/CsvPatientStore.cs
@@ -36,6 +36,7 @@ public class CsvPatientStore(string filePath) : CsvStore<Patient, PatientCsvReco
             PhoneNumber = patient.PhoneNumber,
             AdditionalInfo = patient.Address?.Additional ?? "",
             IsActive = patient.IsActive,
+            IsDeleted = patient.IsDeleted,
         };
     }
 
@@ -59,6 +60,7 @@ public class CsvPatientStore(string filePath) : CsvStore<Patient, PatientCsvReco
         if (TryParseInsuranceStatus(record.InsuranceStatus, out var insuranceStatus))
             patient.SetInsuranceStatus(insuranceStatus);
         patient.IsActive = record.IsActive;
+        patient.IsDeleted = record.IsDeleted;
 
         return patient;
     }

--- a/src/TheraPay.Infrastructure/csv/records/PatientCsvRecord.cs
+++ b/src/TheraPay.Infrastructure/csv/records/PatientCsvRecord.cs
@@ -18,5 +18,6 @@ public sealed class PatientCsvRecord
     public string Email { get; set; } = "";
     public string AdditionalInfo { get; set; } = "";
     public string PhoneNumber { get; set; } = "";
+    public bool IsActive { get; set; } = true;
     public bool IsDeleted { get; set; }
 }

--- a/src/TheraPay.UI/ViewModels/AppointmentEditViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/AppointmentEditViewModel.cs
@@ -139,6 +139,7 @@ public sealed class AppointmentEditViewModel : ViewModelBase
         _appointmentService = appointmentService;
         CalendarPanel = calendarPanel;
         PatientsPanel = patientsPanel;
+        PatientsPanel.ShowOnlyActivePatients = true;
 
         NavigateHomeViewCommand = new RelayCommand(() => nav.NavigateTo<HomeViewModel>());
         SaveAppointmentCommand = new RelayCommand(SaveAppointment);

--- a/src/TheraPay.UI/ViewModels/InvoiceCreationViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/InvoiceCreationViewModel.cs
@@ -50,6 +50,31 @@ public class InvoiceCreationViewModel : ViewModelBase
     public RelayCommand NavigateHomeViewCommand { get; }
     public RelayCommand NavigateInvoiceDraftCommand { get; }
 
+    private bool _showOnlyPatientsWithUnbilledAppointments;
+    public bool ShowOnlyPatientsWithUnbilledAppointments
+    {
+        get => _showOnlyPatientsWithUnbilledAppointments;
+        set
+        {
+            if (_showOnlyPatientsWithUnbilledAppointments == value)
+                return;
+
+            _showOnlyPatientsWithUnbilledAppointments = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(ShowAllInvoicePatients));
+            ApplyPatientAppointmentFilter();
+        }
+    }
+
+    public bool ShowAllInvoicePatients
+    {
+        get => ShowOnlyPatientsWithUnbilledAppointments == false;
+        set
+        {
+            if (value)
+                ShowOnlyPatientsWithUnbilledAppointments = false;
+        }
+    }
 
     public InvoiceCreationViewModel(
         PatientService patientService,
@@ -68,13 +93,28 @@ public class InvoiceCreationViewModel : ViewModelBase
         _billingService = billingService;
         _messageBox = messageBox;
         PatientsPanel = patientsPanel;
+        PatientsPanel.FilterAll = true;
         PatientsPanel.PropertyChanged += OnPatientsPanelPropertyChanged;
+        ShowOnlyPatientsWithUnbilledAppointments = true;
 
         _paymentTermInDays = _session.PracticeData.DefaultPaymentTermDays;
         NavigateHomeViewCommand = new RelayCommand(() => _nav.NavigateTo<HomeViewModel>());
         NavigateInvoiceDraftCommand = new RelayCommand(async () => await ContinueToDraftAsync());
 
         ReloadAppointments();
+    }
+
+    private void ApplyPatientAppointmentFilter()
+    {
+        PatientsPanel.SetAdditionalPatientFilter(
+            ShowOnlyPatientsWithUnbilledAppointments
+                ? PatientHasUnbilledAppointments
+                : null);
+    }
+
+    private bool PatientHasUnbilledAppointments(Patient patient)
+    {
+        return _appointmentService.GetNotBilledAppointmentsForPatient(patient.ID).Any();
     }
 
     public void ReloadAppointments()

--- a/src/TheraPay.UI/ViewModels/InvoicesViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/InvoicesViewModel.cs
@@ -4,11 +4,13 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia.Media;
 using TheraPay.Core;
 using TheraPay.Domain;
 using TheraPay.UI.Navigation;
+using TheraPay.UI.Services;
 using TheraPay.UI.State;
 
 namespace TheraPay.UI.ViewModels;
@@ -27,7 +29,9 @@ public sealed class InvoicesViewModel : ViewModelBase
     private readonly IInvoicePdfExporter _invoiceExporter;
     private readonly ProjectSession _session;
     private readonly NavigationService _nav;
+    private readonly IMessageBoxService _messageBox;
     private readonly RelayCommand _editDraftCommand;
+    private readonly RelayCommand _deleteDraftCommand;
     private readonly RelayCommand _printInvoiceCommand;
 
     public ObservableCollection<InvoiceRowVm> Invoices { get; } = new();
@@ -50,6 +54,7 @@ public sealed class InvoicesViewModel : ViewModelBase
 
     public ICommand NavigateHomeViewCommand { get; }
     public ICommand EditDraftCommand => _editDraftCommand;
+    public ICommand DeleteDraftCommand => _deleteDraftCommand;
     public ICommand PrintInvoiceCommand => _printInvoiceCommand;
 
     private readonly List<Invoice> _allInvoices = new();
@@ -92,6 +97,7 @@ public sealed class InvoicesViewModel : ViewModelBase
             OnPropertyChanged();
             RefreshSelectedInvoiceDetails();
             _editDraftCommand.RaiseCanExecuteChanged();
+            _deleteDraftCommand.RaiseCanExecuteChanged();
             _printInvoiceCommand.RaiseCanExecuteChanged();
         }
     }
@@ -236,16 +242,19 @@ public sealed class InvoicesViewModel : ViewModelBase
         IPatientRepository patientRepository,
         IInvoicePdfExporter invoiceExporter,
         ProjectSession session,
-        NavigationService nav)
+        NavigationService nav,
+        IMessageBoxService messageBox)
     {
         _billingService = billingService;
         _patientRepository = patientRepository;
         _invoiceExporter = invoiceExporter;
         _session = session;
         _nav = nav;
+        _messageBox = messageBox;
 
         NavigateHomeViewCommand = new RelayCommand(() => _nav.NavigateTo<HomeViewModel>());
         _editDraftCommand = new RelayCommand(EditSelectedDraft, CanEditSelectedDraft);
+        _deleteDraftCommand = new RelayCommand(async () => await DeleteSelectedDraftAsync(), CanDeleteSelectedDraft);
         _printInvoiceCommand = new RelayCommand(PrintSelectedInvoice, CanPrintSelectedInvoice);
 
         LoadAllInvoices();
@@ -391,12 +400,14 @@ public sealed class InvoicesViewModel : ViewModelBase
         InvoiceNumber = "-";
         Positions.Clear();
         _editDraftCommand.RaiseCanExecuteChanged();
+        _deleteDraftCommand.RaiseCanExecuteChanged();
         _printInvoiceCommand.RaiseCanExecuteChanged();
     }
 
     private bool CanEditSelectedDraft()
     {
-        return SelectedInvoice?.Invoice.Status == InvoiceStatus.Draft;
+        return SelectedInvoice?.Invoice is { Status: InvoiceStatus.Draft } invoice &&
+               !IsPatientDeletedOrMissing(invoice.PatientData.Id);
     }
 
     private void EditSelectedDraft()
@@ -407,8 +418,60 @@ public sealed class InvoicesViewModel : ViewModelBase
             return;
         }
 
+        if (IsPatientDeletedOrMissing(SelectedInvoice.Invoice.PatientData.Id))
+        {
+            StatusMessage = "Draft kann nicht bearbeitet werden, weil der Patient gelöscht wurde.";
+            return;
+        }
+
         var invoiceId = SelectedInvoice.Invoice.Id;
         _nav.NavigateTo<InvoiceDraftViewModel>(vm => vm.LoadDraft(invoiceId));
+    }
+
+    private bool CanDeleteSelectedDraft()
+    {
+        return SelectedInvoice?.Invoice.Status == InvoiceStatus.Draft;
+    }
+
+    public async Task DeleteSelectedDraftAsync()
+    {
+        if (SelectedInvoice is null || SelectedInvoice.Invoice.Status != InvoiceStatus.Draft)
+        {
+            StatusMessage = "Nur Draft-Rechnungen können gelöscht werden.";
+            return;
+        }
+
+        var confirmed = await _messageBox.ConfirmWarningAsync(
+            "Draft löschen",
+            "Achtung, der Invoice-Draft wird gelöscht! Diese Aktion ist nicht widerrufbar, wollen Sie fortfahren?",
+            "Draft löschen",
+            "Abbrechen");
+        if (!confirmed)
+            return;
+
+        var invoiceId = SelectedInvoice.Invoice.Id;
+        var result = _billingService.DeleteDraftInvoice(invoiceId);
+        if (!result.Ok)
+        {
+            StatusMessage = result.Error ?? "Draft konnte nicht gelöscht werden.";
+            return;
+        }
+
+        _session.MarkUnsavedChanges();
+        StatusMessage = "Draft wurde gelöscht.";
+        LoadAllInvoices();
+    }
+
+    private bool IsPatientDeletedOrMissing(string patientId)
+    {
+        try
+        {
+            return _patientRepository.GetById(patientId).IsDeleted;
+        }
+        catch
+        {
+            return true;
+        }
     }
 
     private bool CanPrintSelectedInvoice()

--- a/src/TheraPay.UI/ViewModels/Panels/PatientPanelViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/Panels/PatientPanelViewModel.cs
@@ -2,18 +2,26 @@ using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using TheraPay.Domain;
 using TheraPay.Core;              // Patient, PatientService (ggf. Namespace anpassen)
 using TheraPay.UI.Navigation;     // NavigationService
+using TheraPay.UI.Services;
+using TheraPay.UI.State;
 using TheraPay.UI.ViewModels;
 
 namespace TheraPay.UI.ViewModels.Panels;
 
 public sealed class PatientPanelViewModel : ViewModelBase
 {
+    private const string DeletePatientWarning =
+        "Achtung, der Patient wird gelöscht! Diese Aktion ist nicht widerrufbar, wollen Sie fortfahren?\n" +
+        "Der Patient wird weiterhin gespeichert, aber nicht mehr angezeigt und nutzbar sein, das gilt auch für die ID.";
     private readonly PatientService _patients;
     private readonly NavigationService _nav;
+    private readonly IMessageBoxService? _messageBox;
+    private readonly ProjectSession? _session;
     private Func<Patient, bool>? _additionalPatientFilter;
 
     public ObservableCollection<PatientRowVm> Patients { get; } = new();
@@ -111,26 +119,49 @@ public sealed class PatientPanelViewModel : ViewModelBase
     public ICommand EditCommand => _editCommand;
     public ICommand DeleteCommand => _deleteCommand;
 
-    public PatientPanelViewModel(PatientService patientService, NavigationService nav)
+    public PatientPanelViewModel(
+        PatientService patientService,
+        NavigationService nav,
+        IMessageBoxService? messageBox = null,
+        ProjectSession? session = null)
     {
         _patients = patientService;
         _nav = nav;
+        _messageBox = messageBox;
+        _session = session;
 
         _editCommand = new RelayCommand(
             execute: () => _nav.NavigateTo<PatientsViewModel>(vm => vm.LoadPatientForEdit(SelectedPatient!.Id)),
             canExecute: () => SelectedPatient is not null);
 
         _deleteCommand = new RelayCommand(
-            execute: () =>
-            {
-                // TODO: SoftDelete im Core:
-                // _patients.SoftDelete(SelectedPatient!.Id);
-                // Reload();
+            execute: async () => await DeleteSelectedPatientAsync(),
+            canExecute: () => SelectedPatient is not null);
 
-                _nav.NavigateTo<PatientsViewModel>(); // MVP
-            },
-            canExecute: () => false);
+        Reload();
+    }
 
+    public async Task DeleteSelectedPatientAsync()
+    {
+        if (SelectedPatient is null || _messageBox is null)
+            return;
+
+        var confirmed = await _messageBox.ConfirmWarningAsync(
+            "Patient löschen",
+            DeletePatientWarning,
+            "Löschen",
+            "Abbrechen");
+        if (!confirmed)
+            return;
+
+        var result = _patients.SoftDeletePatient(SelectedPatient.Id);
+        if (!result.Ok)
+        {
+            await _messageBox.ShowErrorAsync("Patient konnte nicht gelöscht werden", result.Error ?? "Patient konnte nicht gelöscht werden.");
+            return;
+        }
+
+        _session?.MarkUnsavedChanges();
         Reload();
     }
 

--- a/src/TheraPay.UI/ViewModels/Panels/PatientPanelViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/Panels/PatientPanelViewModel.cs
@@ -14,6 +14,7 @@ public sealed class PatientPanelViewModel : ViewModelBase
 {
     private readonly PatientService _patients;
     private readonly NavigationService _nav;
+    private Func<Patient, bool>? _additionalPatientFilter;
 
     public ObservableCollection<PatientRowVm> Patients { get; } = new();
 
@@ -133,8 +134,15 @@ public sealed class PatientPanelViewModel : ViewModelBase
         Reload();
     }
 
+    public void SetAdditionalPatientFilter(Func<Patient, bool>? filter)
+    {
+        _additionalPatientFilter = filter;
+        Reload();
+    }
+
     private void Reload()
     {
+        string? selectedPatientId = SelectedPatient?.Id;
         Patients.Clear();
 
         var all = _patients.ViewPatients().AsEnumerable();
@@ -143,6 +151,9 @@ public sealed class PatientPanelViewModel : ViewModelBase
             all = all.Where(p => p.IsActive);
         else if (FilterArchived)
             all = all.Where(p => p.IsActive == false);
+
+        if (_additionalPatientFilter is not null)
+            all = all.Where(_additionalPatientFilter);
 
         foreach (var p in all)
         {
@@ -161,7 +172,8 @@ public sealed class PatientPanelViewModel : ViewModelBase
             });
         }
 
-        SelectedPatient = Patients.FirstOrDefault();
+        SelectedPatient = Patients.FirstOrDefault(patient => patient.Id == selectedPatientId)
+            ?? Patients.FirstOrDefault();
     }
 
     public void SelectPatient(string patientId)

--- a/src/TheraPay.UI/ViewModels/Panels/PatientPanelViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/Panels/PatientPanelViewModel.cs
@@ -17,6 +17,32 @@ public sealed class PatientPanelViewModel : ViewModelBase
 
     public ObservableCollection<PatientRowVm> Patients { get; } = new();
 
+    private bool _showOnlyActivePatients;
+    public bool ShowOnlyActivePatients
+    {
+        get => _showOnlyActivePatients;
+        set
+        {
+            if (_showOnlyActivePatients == value) return;
+            _showOnlyActivePatients = value;
+            if (value)
+            {
+                _filterAll = false;
+                _filterActive = true;
+                _filterArchived = false;
+                OnPropertyChanged(nameof(FilterAll));
+                OnPropertyChanged(nameof(FilterActive));
+                OnPropertyChanged(nameof(FilterArchived));
+            }
+
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(ShowActivityFilter));
+            Reload();
+        }
+    }
+
+    public bool ShowActivityFilter => ShowOnlyActivePatients == false;
+
     private PatientRowVm? _selectedPatient;
     public PatientRowVm? SelectedPatient
     {
@@ -28,18 +54,18 @@ public sealed class PatientPanelViewModel : ViewModelBase
             OnPropertyChanged();
 
             _editCommand.RaiseCanExecuteChanged();
-            _toggleActiveCommand.RaiseCanExecuteChanged();
             _deleteCommand.RaiseCanExecuteChanged();
         }
     }
 
     // Filter (für MVP reicht es, wenn die Umschaltung schon funktioniert)
-    private bool _filterAll = true;
+    private bool _filterAll;
     public bool FilterAll
     {
         get => _filterAll;
         set
         {
+            if (ShowOnlyActivePatients && value) return;
             if (_filterAll == value) return;
             _filterAll = value;
             if (value) { _filterActive = false; _filterArchived = false; OnPropertyChanged(nameof(FilterActive)); OnPropertyChanged(nameof(FilterArchived)); }
@@ -48,12 +74,13 @@ public sealed class PatientPanelViewModel : ViewModelBase
         }
     }
 
-    private bool _filterActive;
+    private bool _filterActive = true;
     public bool FilterActive
     {
         get => _filterActive;
         set
         {
+            if (ShowOnlyActivePatients && value == false) return;
             if (_filterActive == value) return;
             _filterActive = value;
             if (value) { _filterAll = false; _filterArchived = false; OnPropertyChanged(nameof(FilterAll)); OnPropertyChanged(nameof(FilterArchived)); }
@@ -68,6 +95,7 @@ public sealed class PatientPanelViewModel : ViewModelBase
         get => _filterArchived;
         set
         {
+            if (ShowOnlyActivePatients && value) return;
             if (_filterArchived == value) return;
             _filterArchived = value;
             if (value) { _filterAll = false; _filterActive = false; OnPropertyChanged(nameof(FilterAll)); OnPropertyChanged(nameof(FilterActive)); }
@@ -77,11 +105,9 @@ public sealed class PatientPanelViewModel : ViewModelBase
     }
 
     private readonly RelayCommand _editCommand;
-    private readonly RelayCommand _toggleActiveCommand;
     private readonly RelayCommand _deleteCommand;
 
     public ICommand EditCommand => _editCommand;
-    public ICommand ToggleActiveCommand => _toggleActiveCommand;
     public ICommand DeleteCommand => _deleteCommand;
 
     public PatientPanelViewModel(PatientService patientService, NavigationService nav)
@@ -92,17 +118,6 @@ public sealed class PatientPanelViewModel : ViewModelBase
         _editCommand = new RelayCommand(
             execute: () => _nav.NavigateTo<PatientsViewModel>(vm => vm.LoadPatientForEdit(SelectedPatient!.Id)),
             canExecute: () => SelectedPatient is not null);
-
-        _toggleActiveCommand = new RelayCommand(
-            execute: () =>
-            {
-                // TODO: sobald du im Core eine Toggle/Archive-Funktion hast:
-                // _patients.ToggleActive(SelectedPatient!.Id);
-                // Reload();
-
-                _nav.NavigateTo<PatientsViewModel>(); // MVP: erst mal zur Patientenverwaltung springen
-            },
-            canExecute: () => false);
 
         _deleteCommand = new RelayCommand(
             execute: () =>
@@ -122,11 +137,12 @@ public sealed class PatientPanelViewModel : ViewModelBase
     {
         Patients.Clear();
 
-        var all = _patients.ViewPatients();
+        var all = _patients.ViewPatients().AsEnumerable();
 
-        // MVP: Filterlogik optional. Wenn du später IsArchived/IsActive hast, hier filtern.
-        // if (FilterActive) all = all.Where(p => p.IsActive).ToList();
-        // if (FilterArchived) all = all.Where(p => p.IsArchived).ToList();
+        if (ShowOnlyActivePatients || FilterActive)
+            all = all.Where(p => p.IsActive);
+        else if (FilterArchived)
+            all = all.Where(p => p.IsActive == false);
 
         foreach (var p in all)
         {

--- a/src/TheraPay.UI/ViewModels/PatientsViewModel.cs
+++ b/src/TheraPay.UI/ViewModels/PatientsViewModel.cs
@@ -101,9 +101,24 @@ public class PatientsViewModel : ViewModelBase
     public ObservableCollection<Patient> Patients { get; } = new();
     public IReadOnlyList<PatientInsuranceStatus> InsuranceStatuses { get; } = Enum.GetValues<PatientInsuranceStatus>();
     public bool IsEditMode => _editingPatientId is not null;
-    public bool IsPatientIdEditable => IsEditMode == false;
+    public bool IsPatientIdEditable => IsEditMode == false && IsPatientDataEditable;
     public string PatientFormTitle => IsEditMode ? "Patient bearbeiten" : "Patient hinzufügen";
     public string SavePatientButtonText => IsEditMode ? "Änderungen speichern" : "Hinzufügen";
+
+    private bool _isPatientDataEditable = true;
+    public bool IsPatientDataEditable
+    {
+        get => _isPatientDataEditable;
+        set
+        {
+            if (_isPatientDataEditable == value)
+                return;
+
+            _isPatientDataEditable = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsPatientIdEditable));
+        }
+    }
 
     private string _checkDataMessage = "";
     public string CheckDataMessage
@@ -147,6 +162,7 @@ public class PatientsViewModel : ViewModelBase
         {
             _editingPatientId = null;
             PatientFields = new PatientFields();
+            IsPatientDataEditable = true;
             CheckDataMessage = $"Patient mit ID '{patientId}' wurde nicht gefunden.";
             NotifyEditModeChanged();
             return;
@@ -154,6 +170,7 @@ public class PatientsViewModel : ViewModelBase
 
         _editingPatientId = patient.ID;
         PatientFields = PatientFields.FromPatient(patient);
+        IsPatientDataEditable = false;
         CheckDataMessage = "";
         NotifyEditModeChanged();
     }

--- a/src/TheraPay.UI/Views/InvoiceCreationView.axaml
+++ b/src/TheraPay.UI/Views/InvoiceCreationView.axaml
@@ -42,8 +42,18 @@
         </dataGrid:DataGrid>
       </StackPanel>
     
-    <panels:PatientPanelView Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="1"
-                          DataContext="{Binding PatientsPanel}" />
+    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="1" Spacing="6">
+      <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+        <TextBlock Text="Patientenfilter:" VerticalAlignment="Center"/>
+        <RadioButton GroupName="InvoicePatientFilter"
+                     Content="ohne Terminfilter"
+                     IsChecked="{Binding ShowAllInvoicePatients, Mode=TwoWay}" />
+        <RadioButton GroupName="InvoicePatientFilter"
+                     Content="mit nicht abgerechneten Terminen"
+                     IsChecked="{Binding ShowOnlyPatientsWithUnbilledAppointments, Mode=TwoWay}" />
+      </StackPanel>
+      <panels:PatientPanelView DataContext="{Binding PatientsPanel}" />
+    </StackPanel>
 
     <StackPanel Spacing="8" Grid.Row="0" Grid.Column="1" Orientation="Vertical" >
 

--- a/src/TheraPay.UI/Views/InvoicesView.axaml
+++ b/src/TheraPay.UI/Views/InvoicesView.axaml
@@ -63,6 +63,12 @@
                   MinWidth="220"
                   HorizontalAlignment="Stretch"
                   Background="#71CE82" />
+          <Button Content="Draft Löschen"
+                  Command="{Binding DeleteDraftCommand}"
+                  MinWidth="220"
+                  HorizontalAlignment="Stretch"
+                  Background="#D9534F"
+                  Foreground="White" />
           <Button Content="Rechnung erneut drucken"
                   Command="{Binding PrintInvoiceCommand}"
                   MinWidth="220"

--- a/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
+++ b/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
@@ -53,7 +53,7 @@
 
           <!-- Aktionen -->
           <StackPanel Spacing="8" Margin="8" Grid.Column="2">
-            <Button Content="Bearbeiten" Command="{Binding EditCommand}" />
+            <Button Content="Bearbeiten/Ansehen" Command="{Binding EditCommand}" />
             <Button Content="(In)aktivieren" Command="{Binding ToggleActiveCommand}" />
             <Button Content="Löschen" Command="{Binding DeleteCommand}" />
           </StackPanel>

--- a/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
+++ b/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
@@ -24,10 +24,13 @@
           <StackPanel Spacing="8" Margin="8" Grid.Column="0">
           <TextBlock Text="Patienten:" FontSize="18" FontWeight="Bold"/>
             <RadioButton GroupName="PatientenFilter" Content="alle"
+                         IsVisible="{Binding ShowActivityFilter}"
                          IsChecked="{Binding FilterAll, Mode=TwoWay}" />
             <RadioButton GroupName="PatientenFilter" Content="aktiv"
+                         IsVisible="{Binding ShowActivityFilter}"
                          IsChecked="{Binding FilterActive, Mode=TwoWay}" />
-            <RadioButton GroupName="PatientenFilter" Content="archiviert"
+            <RadioButton GroupName="PatientenFilter" Content="inaktiv"
+                         IsVisible="{Binding ShowActivityFilter}"
                          IsChecked="{Binding FilterArchived, Mode=TwoWay}" />
           </StackPanel>
 
@@ -53,8 +56,7 @@
 
           <!-- Aktionen -->
           <StackPanel Spacing="8" Margin="8" Grid.Column="2">
-            <Button Content="Bearbeiten/Ansehen" Command="{Binding EditCommand}" />
-            <Button Content="(In)aktivieren" Command="{Binding ToggleActiveCommand}" />
+            <Button Content="Bearbeiten/&#x0a;Ansehen" Command="{Binding EditCommand}" />
             <Button Content="Löschen" Command="{Binding DeleteCommand}" />
           </StackPanel>
 

--- a/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
+++ b/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
@@ -21,7 +21,7 @@
               ColumnSpacing="16">
 
           <!-- Filter -->
-          <StackPanel Spacing="8" Margin="8" Grid.Column="0">
+          <StackPanel Spacing="8" Margin="8" Grid.Column="0" Grid.Row="0">
           <TextBlock Text="Patienten:" FontSize="18" FontWeight="Bold"/>
             <RadioButton GroupName="PatientenFilter" Content="alle"
                          IsVisible="{Binding ShowActivityFilter}"
@@ -36,6 +36,7 @@
 
           <!-- Patientenliste -->
           <dataGrid:DataGrid Grid.Column="1"
+                             Grid.RowSpan="2"
                              ItemsSource="{Binding Patients}"
                              SelectedItem="{Binding SelectedPatient, Mode=TwoWay}"
                              AutoGenerateColumns="False"
@@ -55,7 +56,7 @@
           </dataGrid:DataGrid>
 
           <!-- Aktionen -->
-          <StackPanel Spacing="8" Margin="8" Grid.Column="2">
+          <StackPanel Spacing="8" Margin="8" Grid.Column="0" Grid.Row="1">
             <Button Content="Bearbeiten/&#x0a;Ansehen" Command="{Binding EditCommand}" />
             <Button Content="Löschen" Command="{Binding DeleteCommand}" />
           </StackPanel>

--- a/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
+++ b/src/TheraPay.UI/Views/Panels/PatientPanelView.axaml
@@ -21,7 +21,7 @@
               ColumnSpacing="16">
 
           <!-- Filter -->
-          <StackPanel Spacing="8" Margin="8" Grid.Column="0" Grid.Row="0">
+          <StackPanel Spacing="8" Margin="2" Grid.Column="0" Grid.Row="0">
           <TextBlock Text="Patienten:" FontSize="18" FontWeight="Bold"/>
             <RadioButton GroupName="PatientenFilter" Content="alle"
                          IsVisible="{Binding ShowActivityFilter}"
@@ -56,7 +56,7 @@
           </dataGrid:DataGrid>
 
           <!-- Aktionen -->
-          <StackPanel Spacing="8" Margin="8" Grid.Column="0" Grid.Row="1">
+          <StackPanel Spacing="8" Margin="2" Grid.Column="0" Grid.Row="1">
             <Button Content="Bearbeiten/&#x0a;Ansehen" Command="{Binding EditCommand}" />
             <Button Content="Löschen" Command="{Binding DeleteCommand}" />
           </StackPanel>

--- a/src/TheraPay.UI/Views/PatientsView.axaml
+++ b/src/TheraPay.UI/Views/PatientsView.axaml
@@ -11,7 +11,7 @@
 
     <Grid ColumnDefinitions="Auto,*" Margin="16" ColumnSpacing="16" RowDefinitions="Auto,Auto,Auto,Auto,*" RowSpacing="16">
 
-    <StackPanel Orientation="Horizontal" Grid.Row= "0" Grid.Column="0" Spacing="8">
+    <StackPanel Orientation="Horizontal" Grid.Row= "0" Grid.Column="0" Spacing="8" IsEnabled="{Binding IsPatientDataEditable}">
       <StackPanel Orientation="Vertical" Grid.Row= "0" Grid.Column="0" Spacing="8">
        <TextBlock Text="Anrede" FontSize="15"/>
        <ComboBox Width="110"
@@ -40,7 +40,7 @@
       </StackPanel>
     </StackPanel>
 
-    <StackPanel Orientation="Horizontal" Grid.Row= "1" Grid.Column="0" Spacing="8">
+    <StackPanel Orientation="Horizontal" Grid.Row= "1" Grid.Column="0" Spacing="8" IsEnabled="{Binding IsPatientDataEditable}">
       <StackPanel Orientation="Vertical" Grid.Row= "1" Grid.Column="0" Spacing="8">
        <TextBlock Text="Straße" FontSize="15"/>
        <TextBox Width="160" Watermark="Straße" Text="{Binding PatientFields.Street, Mode=TwoWay}"/>
@@ -63,7 +63,7 @@
       </StackPanel>
     </StackPanel>
 
-    <StackPanel Orientation="Horizontal" Grid.Row= "2" Grid.Column="0" Spacing="8">
+    <StackPanel Orientation="Horizontal" Grid.Row= "2" Grid.Column="0" Spacing="8" IsEnabled="{Binding IsPatientDataEditable}">
       <StackPanel Orientation="Vertical" Grid.Row= "2" Grid.Column="0" Spacing="8">
        <TextBlock Text="E-Mail" FontSize="15"/>
        <TextBox Classes="codeInput" Width="160" Watermark="E-Mail" Text="{Binding PatientFields.Email, Mode=TwoWay}"/>
@@ -86,7 +86,7 @@
 
 
 
-    <StackPanel Orientation="Horizontal" Grid.Row= "3" Grid.Column="0" Spacing="8">
+    <StackPanel Orientation="Horizontal" Grid.Row= "3" Grid.Column="0" Spacing="8" IsEnabled="{Binding IsPatientDataEditable}">
       <StackPanel Orientation="Vertical" Grid.Row= "3" Grid.Column="0" Spacing="8">
        <TextBlock Text="Adresszusatz" FontSize="15"/>
        <TextBox Width="500" Height="150" AcceptsReturn="True" TextWrapping="Wrap" Watermark="Adresszusatz" Text="{Binding PatientFields.AdditionalInfo, Mode=TwoWay}"/>
@@ -94,20 +94,21 @@
     </StackPanel>
 
 
-    <StackPanel Orientation="Vertical" Spacing="8" Margin="8" Grid.Column="0" Grid.Row= "4" >
+    <StackPanel Orientation="Vertical" Spacing="8" Margin="8" Grid.Column="0" Grid.Row= "4" IsEnabled="{Binding IsPatientDataEditable}">
       <TextBlock Text="Status:" FontSize="15"/>
       <RadioButton GroupName="PatientenStatus" Content="aktiv" IsChecked="{Binding PatientFields.IsActive, Mode=TwoWay}"/>
       <RadioButton GroupName="PatientenStatus" Content="inaktiv" IsChecked="{Binding PatientFields.IsInactive, Mode=TwoWay}"/>
     </StackPanel>
     <StackPanel Orientation="Vertical" Grid.Row= "4" Grid.Column="1" Spacing="8">
-      <Button Content="Daten prüfen" Command="{Binding CheckDataCommand}" Background="#FAAC2D" HorizontalAlignment="Right"/>
-      <Button Content="{Binding SavePatientButtonText}" Command="{Binding AddPatientCommand}" Background="#71CE82" HorizontalAlignment="Right"/>
+      <Button Content="Daten prüfen" Command="{Binding CheckDataCommand}" Background="#FAAC2D" HorizontalAlignment="Right" IsEnabled="{Binding IsPatientDataEditable}"/>
+      <Button Content="{Binding SavePatientButtonText}" Command="{Binding AddPatientCommand}" Background="#71CE82" HorizontalAlignment="Right" IsEnabled="{Binding IsPatientDataEditable}"/>
       <TextBlock Text="{Binding CheckDataMessage}" TextWrapping="Wrap" MaxWidth="260" HorizontalAlignment="Right" Foreground="Red" FontWeight="Bold"/>
     </StackPanel>
 
 
     <StackPanel Orientation="Vertical" Grid.Row= "0" Grid.Column="1" Spacing="8">
       <Button Content="Zurück" Command="{Binding NavigateHomeViewCommand}" Background="#AA3A3A" HorizontalAlignment="Right"/>
+      <CheckBox Content="Bearbeiten" IsChecked="{Binding IsPatientDataEditable}" HorizontalAlignment="Right"/>
     </StackPanel>
   
     </Grid>

--- a/tests/TheraPay.Core.Tests/BillingService_test.cs
+++ b/tests/TheraPay.Core.Tests/BillingService_test.cs
@@ -178,6 +178,54 @@ public class BillingService_test
     }
 
     [Fact]
+    public void GivenDraftInvoice_DeleteDraftInvoice_RemovesDraft()
+    {
+        // GIVEN
+        IInvoiceRepository invoiceRepo = new InMemoryInvoiceRepository();
+        IAppointmentRepository appointmentRepo = TestData.getInMemoryInMemoryAppointmentRepositoryWithTwoAppointments();
+        IPatientRepository patientRepo = TestData.getInMemoryPatientRepositoryWithTwoPatients();
+        var service = new BillingService(invoiceRepo, appointmentRepo, patientRepo);
+        var patientId = TestData.Patient1().ID;
+        var appointmentId = appointmentRepo.GetByIndex(0).Id;
+        var addResult = service.AddInvoiceForPatientAndAppointments(patientId, [appointmentId], TestData.PracticeData1());
+        Assert.True(addResult.Ok);
+        var draft = Assert.Single(service.ViewInvoices());
+
+        // WHEN
+        var deleteResult = service.DeleteDraftInvoice(draft.Id);
+
+        // THEN
+        Assert.True(deleteResult.Ok);
+        Assert.Empty(service.ViewInvoices());
+    }
+
+    [Fact]
+    public void GivenIssuedInvoice_DeleteDraftInvoice_DoesNotRemoveInvoice()
+    {
+        // GIVEN
+        IInvoiceRepository invoiceRepo = new InMemoryInvoiceRepository();
+        IAppointmentRepository appointmentRepo = TestData.getInMemoryInMemoryAppointmentRepositoryWithTwoAppointments();
+        IPatientRepository patientRepo = TestData.getInMemoryPatientRepositoryWithTwoPatients();
+        var service = new BillingService(invoiceRepo, appointmentRepo, patientRepo);
+        var practiceData = TestData.PracticeData1();
+        var patientId = TestData.Patient1().ID;
+        var appointmentId = appointmentRepo.GetByIndex(0).Id;
+        var addResult = service.AddInvoiceForPatientAndAppointments(patientId, [appointmentId], practiceData);
+        Assert.True(addResult.Ok);
+        var invoice = Assert.Single(service.ViewInvoices());
+        var issueResult = service.IssueInvoice(invoice, DateTime.Today, practiceData);
+        Assert.True(issueResult.Ok);
+
+        // WHEN
+        var deleteResult = service.DeleteDraftInvoice(invoice.Id);
+
+        // THEN
+        Assert.False(deleteResult.Ok);
+        Assert.Single(service.ViewInvoices());
+        Assert.Equal(InvoiceStatus.Issued, invoice.Status);
+    }
+
+    [Fact]
     public void GivenAppointmentsAndPatients_AddInvoiceForPatientAndAppointmentsWithMismatchingPatientId_InvoiceIsNotAddedToInvoiceRepository()
     {
         // GIVEN

--- a/tests/TheraPay.Core.Tests/PatientService_test.cs
+++ b/tests/TheraPay.Core.Tests/PatientService_test.cs
@@ -239,4 +239,57 @@ public class PatientService_test
         Assert.False(result.Ok);
     }
 
+    [Fact]
+    public void GivenExistingPatient_SoftDeletePatient_HidesPatientButKeepsRepositoryEntryAndIdReserved()
+    {
+        // GIVEN
+        InMemoryPatientRepository repository = TestData.getInMemoryPatientRepositoryWithTwoPatients();
+        PatientService service = new PatientService(repository);
+        Patient patient = repository.GetById("L5R");
+
+        // WHEN
+        Result deleteResult = service.SoftDeletePatient(patient.ID);
+        Result addSameIdResult = service.AddPatient("New", "Patient", patient.ID);
+
+        // THEN
+        Assert.True(deleteResult.Ok);
+        Assert.True(patient.IsDeleted);
+        Assert.False(patient.IsActive);
+        Assert.Equal(2, repository.Count());
+        Assert.DoesNotContain(service.ViewPatients(), visiblePatient => visiblePatient.ID == patient.ID);
+        Assert.Null(service.FindPatientById(patient.ID));
+        Assert.False(addSameIdResult.Ok);
+    }
+
+    [Fact]
+    public void GivenDeletedPatient_UpdatePatient_ResultIsNotOk()
+    {
+        // GIVEN
+        InMemoryPatientRepository repository = TestData.getInMemoryPatientRepositoryWithTwoPatients();
+        PatientService service = new PatientService(repository);
+        Patient patient = repository.GetById("L5R");
+        service.SoftDeletePatient(patient.ID);
+
+        // WHEN
+        Result result = service.UpdatePatient(
+            patient.ID,
+            "Grace",
+            "Hopper",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "Privat",
+            true);
+
+        // THEN
+        Assert.False(result.Ok);
+        Assert.True(patient.IsDeleted);
+    }
+
 }

--- a/tests/TheraPay.Infrastructure.csv.Tests/CsvPatientStore_test.cs
+++ b/tests/TheraPay.Infrastructure.csv.Tests/CsvPatientStore_test.cs
@@ -50,6 +50,7 @@ public class CsvPatientStore_test
         Assert.Equal("3", patients[2].ID);
         Assert.Equal("Third", patients[2].FirstName);
         Assert.Equal("Three", patients[2].LastName);
+        Assert.True(patients[2].IsDeleted);
         Assert.All(patients, patient => Assert.True(patient.IsActive));
     }
 
@@ -85,6 +86,7 @@ public class CsvPatientStore_test
         thirdPatient.SetDateOfBirth(new DateOnly(1985, 9, 30));
         thirdPatient.SetInsuranceStatus(PatientInsuranceStatus.Selbstzahler);
         thirdPatient.IsActive = false;
+        thirdPatient.IsDeleted = true;
         var patients = new List<Patient>
         {
             new Patient("Firstt", "One", "1"),
@@ -114,11 +116,13 @@ public class CsvPatientStore_test
         Assert.Equal(patients[2].DateOfBirth, loadedPatients[2].DateOfBirth);
         Assert.Equal(patients[2].InsuranceStatus, loadedPatients[2].InsuranceStatus);
         Assert.False(loadedPatients[2].IsActive);
+        Assert.True(loadedPatients[2].IsDeleted);
 
         string savedCsv = File.ReadAllText(filePath);
         Assert.Contains("Salutation", savedCsv);
         Assert.Contains("DateOfBirth", savedCsv);
         Assert.Contains("IsActive", savedCsv);
+        Assert.Contains("IsDeleted", savedCsv);
         Assert.Contains("1991-04-12", savedCsv);
         Assert.Contains("False", savedCsv);
 

--- a/tests/TheraPay.Infrastructure.csv.Tests/CsvPatientStore_test.cs
+++ b/tests/TheraPay.Infrastructure.csv.Tests/CsvPatientStore_test.cs
@@ -50,6 +50,7 @@ public class CsvPatientStore_test
         Assert.Equal("3", patients[2].ID);
         Assert.Equal("Third", patients[2].FirstName);
         Assert.Equal("Three", patients[2].LastName);
+        Assert.All(patients, patient => Assert.True(patient.IsActive));
     }
 
     [Fact]
@@ -83,6 +84,7 @@ public class CsvPatientStore_test
         thirdPatient.SetSalutation("Divers");
         thirdPatient.SetDateOfBirth(new DateOnly(1985, 9, 30));
         thirdPatient.SetInsuranceStatus(PatientInsuranceStatus.Selbstzahler);
+        thirdPatient.IsActive = false;
         var patients = new List<Patient>
         {
             new Patient("Firstt", "One", "1"),
@@ -111,11 +113,36 @@ public class CsvPatientStore_test
         Assert.Equal(patients[2].LastName, loadedPatients[2].LastName);
         Assert.Equal(patients[2].DateOfBirth, loadedPatients[2].DateOfBirth);
         Assert.Equal(patients[2].InsuranceStatus, loadedPatients[2].InsuranceStatus);
+        Assert.False(loadedPatients[2].IsActive);
 
         string savedCsv = File.ReadAllText(filePath);
         Assert.Contains("Salutation", savedCsv);
         Assert.Contains("DateOfBirth", savedCsv);
+        Assert.Contains("IsActive", savedCsv);
         Assert.Contains("1991-04-12", savedCsv);
+        Assert.Contains("False", savedCsv);
+
+        File.Delete(filePath);
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void GivenCsvWithIsActive_LoadAll_RestoresInactivePatients()
+    {
+        // Given
+        var filePath = TestPaths.DataFile("testLoadActivePatients.csv");
+        File.WriteAllText(
+            filePath,
+            "Id,FirstName,LastName,IsActive\nACTIVE,Ada,Active,True\nINACTIVE,Ida,Inactive,False\n");
+        var csvPatientStore = new CsvPatientStore(filePath);
+
+        // When
+        var patients = csvPatientStore.LoadAll();
+
+        // Then
+        Assert.Equal(2, patients.Count);
+        Assert.True(patients[0].IsActive);
+        Assert.False(patients[1].IsActive);
 
         File.Delete(filePath);
         Assert.False(File.Exists(filePath));

--- a/tests/TheraPay.UI.Tests/InvoiceCreationViewModel_test.cs
+++ b/tests/TheraPay.UI.Tests/InvoiceCreationViewModel_test.cs
@@ -13,6 +13,54 @@ namespace TheraPay.UI.Tests;
 public class InvoiceCreationViewModel_test
 {
     [Fact]
+    public void GivenPatientsWithDifferentAppointmentStates_FilterOnlyPatientsWithUnbilledAppointments_ShowsOnlyMatchingPatients()
+    {
+        // GIVEN
+        var invoiceRepository = new InMemoryInvoiceRepository();
+        var appointmentRepository = new InMemoryAppointmentRepository();
+        var patientRepository = new InMemoryPatientRepository();
+
+        var patientWithOpenAppointment = new Patient("Ada", "Open", "OPEN");
+        var inactivePatientWithOpenAppointment = new Patient("Ina", "InactiveOpen", "INACTIVE_OPEN")
+        {
+            IsActive = false
+        };
+        var patientWithOnlyBilledAppointment = new Patient("Bill", "Billed", "BILLED");
+        var patientWithoutAppointment = new Patient("Nora", "None", "NONE");
+        patientRepository.Add(patientWithOpenAppointment);
+        patientRepository.Add(inactivePatientWithOpenAppointment);
+        patientRepository.Add(patientWithOnlyBilledAppointment);
+        patientRepository.Add(patientWithoutAppointment);
+
+        var openAppointment = new Appointment(new DateTime(2026, 1, 1, 9, 0, 0), patientWithOpenAppointment.ID);
+        var inactiveOpenAppointment = new Appointment(new DateTime(2026, 1, 2, 9, 0, 0), inactivePatientWithOpenAppointment.ID);
+        var billedAppointment = new Appointment(new DateTime(2026, 1, 3, 9, 0, 0), patientWithOnlyBilledAppointment.ID);
+        billedAppointment.SetStatusToBilled();
+        appointmentRepository.Add(openAppointment);
+        appointmentRepository.Add(inactiveOpenAppointment);
+        appointmentRepository.Add(billedAppointment);
+
+        var viewModel = CreateViewModel(invoiceRepository, appointmentRepository, patientRepository);
+
+        // THEN
+        Assert.True(viewModel.ShowAllInvoicePatients);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOpenAppointment.ID);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == inactivePatientWithOpenAppointment.ID);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOnlyBilledAppointment.ID);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithoutAppointment.ID);
+
+        // WHEN
+        viewModel.ShowOnlyPatientsWithUnbilledAppointments = true;
+
+        // THEN
+        Assert.False(viewModel.ShowAllInvoicePatients);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOpenAppointment.ID);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == inactivePatientWithOpenAppointment.ID);
+        Assert.DoesNotContain(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOnlyBilledAppointment.ID);
+        Assert.DoesNotContain(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithoutAppointment.ID);
+    }
+
+    [Fact]
     public void GivenSelectedAppointmentAlreadyInDraft_ContinueToDraft_WarnsAndRequiresConfirmation()
     {
         // GIVEN
@@ -82,6 +130,31 @@ public class InvoiceCreationViewModel_test
         Assert.Equal(2, billingService.ViewInvoices().Count);
         Assert.Equal(1, messageBox.ConfirmationCount);
         Assert.Contains("bereits in anderen Drafts", messageBox.LastConfirmationMessage);
+    }
+
+    private static InvoiceCreationViewModel CreateViewModel(
+        InMemoryInvoiceRepository invoiceRepository,
+        InMemoryAppointmentRepository appointmentRepository,
+        InMemoryPatientRepository patientRepository)
+    {
+        var patientService = new PatientService(patientRepository);
+        var appointmentService = new AppointmentService(appointmentRepository);
+        var billingService = new BillingService(invoiceRepository, appointmentRepository, patientRepository);
+        var session = new ProjectSession();
+        session.SetPracticeData(new PracticeData { DefaultPaymentTermDays = 14 });
+        var messageBox = new ConfirmingMessageBoxService();
+        var navigationService = new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider());
+        var patientsPanel = new PatientPanelViewModel(patientService, navigationService);
+
+        return new InvoiceCreationViewModel(
+            patientService,
+            appointmentService,
+            billingService,
+            patientsPanel,
+            patientRepository,
+            session,
+            navigationService,
+            messageBox);
     }
 
     private sealed class NoopInvoicePdfExporter : IInvoicePdfExporter

--- a/tests/TheraPay.UI.Tests/InvoiceCreationViewModel_test.cs
+++ b/tests/TheraPay.UI.Tests/InvoiceCreationViewModel_test.cs
@@ -43,21 +43,21 @@ public class InvoiceCreationViewModel_test
         var viewModel = CreateViewModel(invoiceRepository, appointmentRepository, patientRepository);
 
         // THEN
+        Assert.True(viewModel.ShowOnlyPatientsWithUnbilledAppointments);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOpenAppointment.ID);
+        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == inactivePatientWithOpenAppointment.ID);
+        Assert.DoesNotContain(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOnlyBilledAppointment.ID);
+        Assert.DoesNotContain(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithoutAppointment.ID);
+
+        // WHEN
+        viewModel.ShowAllInvoicePatients = true;
+
+        // THEN
         Assert.True(viewModel.ShowAllInvoicePatients);
         Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOpenAppointment.ID);
         Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == inactivePatientWithOpenAppointment.ID);
         Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOnlyBilledAppointment.ID);
         Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithoutAppointment.ID);
-
-        // WHEN
-        viewModel.ShowOnlyPatientsWithUnbilledAppointments = true;
-
-        // THEN
-        Assert.False(viewModel.ShowAllInvoicePatients);
-        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOpenAppointment.ID);
-        Assert.Contains(viewModel.PatientsPanel.Patients, patient => patient.Id == inactivePatientWithOpenAppointment.ID);
-        Assert.DoesNotContain(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithOnlyBilledAppointment.ID);
-        Assert.DoesNotContain(viewModel.PatientsPanel.Patients, patient => patient.Id == patientWithoutAppointment.ID);
     }
 
     [Fact]

--- a/tests/TheraPay.UI.Tests/InvoicesViewModel_test.cs
+++ b/tests/TheraPay.UI.Tests/InvoicesViewModel_test.cs
@@ -4,6 +4,7 @@ using TheraPay.Core;
 using TheraPay.Core.Export;
 using TheraPay.Domain;
 using TheraPay.UI.Navigation;
+using TheraPay.UI.Services;
 using TheraPay.UI.State;
 using TheraPay.UI.ViewModels;
 
@@ -21,7 +22,8 @@ public class InvoicesViewModel_test
             setup.PatientRepository,
             setup.Exporter,
             setup.Session,
-            setup.NavigationService);
+            setup.NavigationService,
+            setup.MessageBox);
 
         // THEN
         Assert.Single(viewModel.Invoices);
@@ -57,7 +59,8 @@ public class InvoicesViewModel_test
             setup.PatientRepository,
             setup.Exporter,
             setup.Session,
-            setup.NavigationService);
+            setup.NavigationService,
+            setup.MessageBox);
 
         try
         {
@@ -100,7 +103,8 @@ public class InvoicesViewModel_test
             setup.PatientRepository,
             setup.Exporter,
             setup.Session,
-            setup.NavigationService);
+            setup.NavigationService,
+            setup.MessageBox);
 
         // THEN
         Assert.Equal(InvoiceStatus.Overdue, invoice.Status);
@@ -125,6 +129,76 @@ public class InvoicesViewModel_test
         Assert.Equal("Overdue", viewModel.SelectedInvoice!.Status);
         Assert.Equal(nameof(InvoiceStatus.Issued), viewModel.SelectedEditableInvoiceStatus);
         Assert.Equal(Brush.Parse("#FFC6B3").ToString(), viewModel.InvoiceStatusBackground.ToString());
+    }
+
+    [Fact]
+    public void GivenDraftInvoiceForDeletedPatient_OverviewDoesNotAllowEditingButAllowsDeleting()
+    {
+        // GIVEN
+        var setup = CreateSetup();
+        setup.PatientRepository.GetById("AL1").IsDeleted = true;
+
+        var viewModel = new InvoicesViewModel(
+            setup.BillingService,
+            setup.PatientRepository,
+            setup.Exporter,
+            setup.Session,
+            setup.NavigationService,
+            setup.MessageBox);
+
+        // THEN
+        Assert.False(viewModel.EditDraftCommand.CanExecute(null));
+        Assert.True(viewModel.DeleteDraftCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task GivenSelectedDraft_DeleteSelectedDraftAsync_WhenConfirmed_RemovesDraftAndMarksSession()
+    {
+        // GIVEN
+        var setup = CreateSetup();
+        setup.Session.MarkSaved();
+        var viewModel = new InvoicesViewModel(
+            setup.BillingService,
+            setup.PatientRepository,
+            setup.Exporter,
+            setup.Session,
+            setup.NavigationService,
+            setup.MessageBox);
+
+        // WHEN
+        await viewModel.DeleteSelectedDraftAsync();
+
+        // THEN
+        Assert.Empty(setup.BillingService.ViewInvoices());
+        Assert.Null(viewModel.SelectedInvoice);
+        Assert.False(viewModel.DeleteDraftCommand.CanExecute(null));
+        Assert.True(setup.Session.HasUnsavedChanges);
+        Assert.Equal(1, setup.MessageBox.ConfirmationCount);
+        Assert.Contains("Draft wurde gelöscht", viewModel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task GivenSelectedDraft_DeleteSelectedDraftAsync_WhenCancelled_KeepsDraft()
+    {
+        // GIVEN
+        var setup = CreateSetup();
+        setup.MessageBox.ConfirmationResult = false;
+        setup.Session.MarkSaved();
+        var viewModel = new InvoicesViewModel(
+            setup.BillingService,
+            setup.PatientRepository,
+            setup.Exporter,
+            setup.Session,
+            setup.NavigationService,
+            setup.MessageBox);
+
+        // WHEN
+        await viewModel.DeleteSelectedDraftAsync();
+
+        // THEN
+        Assert.Single(setup.BillingService.ViewInvoices());
+        Assert.False(setup.Session.HasUnsavedChanges);
+        Assert.Equal(1, setup.MessageBox.ConfirmationCount);
     }
 
     private static TestSetup CreateSetup()
@@ -176,6 +250,7 @@ public class InvoicesViewModel_test
             new CapturingInvoicePdfExporter(),
             session,
             new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider()),
+            new ConfirmingMessageBoxService(),
             practiceData,
             exportDirectory);
     }
@@ -186,6 +261,7 @@ public class InvoicesViewModel_test
         CapturingInvoicePdfExporter Exporter,
         ProjectSession Session,
         NavigationService NavigationService,
+        ConfirmingMessageBoxService MessageBox,
         PracticeData PracticeData,
         string ExportDirectory);
 
@@ -199,6 +275,28 @@ public class InvoicesViewModel_test
             LastFilePath = filePath;
             LastInvoice = invoice;
             return true;
+        }
+    }
+
+    private sealed class ConfirmingMessageBoxService : IMessageBoxService
+    {
+        public bool ConfirmationResult { get; set; } = true;
+        public int ConfirmationCount { get; private set; }
+
+        public Task ShowErrorAsync(string title, string message)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ShowWarningAsync(string title, string message)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ConfirmWarningAsync(string title, string message, string confirmText = "OK", string cancelText = "Abbrechen")
+        {
+            ConfirmationCount++;
+            return Task.FromResult(ConfirmationResult);
         }
     }
 }

--- a/tests/TheraPay.UI.Tests/PatientPanelViewModel_test.cs
+++ b/tests/TheraPay.UI.Tests/PatientPanelViewModel_test.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using TheraPay.Core;
 using TheraPay.Domain;
 using TheraPay.UI.Navigation;
+using TheraPay.UI.Services;
+using TheraPay.UI.State;
 using TheraPay.UI.ViewModels.Panels;
 
 public class PatientPanelViewModel_test
@@ -61,6 +63,56 @@ public class PatientPanelViewModel_test
         Assert.Equal("ACTIVE", activePatient.Id);
     }
 
+    [Fact]
+    public async Task GivenSelectedPatient_DeleteSelectedPatientAsync_WhenConfirmed_SoftDeletesAndRemovesPatient()
+    {
+        // GIVEN
+        var patientRepository = new InMemoryPatientRepository();
+        patientRepository.Add(new Patient("Ada", "Active", "ACTIVE"));
+        var patientService = new PatientService(patientRepository);
+        var navigationService = new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider());
+        var messageBox = new ConfirmingMessageBoxService(confirm: true);
+        var session = new ProjectSession();
+        var panel = new PatientPanelViewModel(patientService, navigationService, messageBox, session);
+        panel.SelectPatient("ACTIVE");
+
+        // WHEN
+        await panel.DeleteSelectedPatientAsync();
+
+        // THEN
+        Patient patient = patientRepository.GetById("ACTIVE");
+        Assert.True(patient.IsDeleted);
+        Assert.False(patient.IsActive);
+        Assert.Empty(panel.Patients);
+        Assert.True(session.HasUnsavedChanges);
+        Assert.Equal(1, messageBox.ConfirmationCount);
+        Assert.Contains("nicht widerrufbar", messageBox.LastConfirmationMessage);
+    }
+
+    [Fact]
+    public async Task GivenSelectedPatient_DeleteSelectedPatientAsync_WhenCancelled_KeepsPatient()
+    {
+        // GIVEN
+        var patientRepository = new InMemoryPatientRepository();
+        patientRepository.Add(new Patient("Ada", "Active", "ACTIVE"));
+        var patientService = new PatientService(patientRepository);
+        var navigationService = new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider());
+        var messageBox = new ConfirmingMessageBoxService(confirm: false);
+        var session = new ProjectSession();
+        var panel = new PatientPanelViewModel(patientService, navigationService, messageBox, session);
+        panel.SelectPatient("ACTIVE");
+
+        // WHEN
+        await panel.DeleteSelectedPatientAsync();
+
+        // THEN
+        Patient patient = patientRepository.GetById("ACTIVE");
+        Assert.False(patient.IsDeleted);
+        Assert.Single(panel.Patients);
+        Assert.False(session.HasUnsavedChanges);
+        Assert.Equal(1, messageBox.ConfirmationCount);
+    }
+
     private static PatientPanelViewModel CreatePanelWithActiveAndInactivePatients()
     {
         var patientRepository = new InMemoryPatientRepository();
@@ -74,5 +126,34 @@ public class PatientPanelViewModel_test
         var navigationService = new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider());
 
         return new PatientPanelViewModel(patientService, navigationService);
+    }
+
+    private sealed class ConfirmingMessageBoxService : IMessageBoxService
+    {
+        private readonly bool _confirm;
+        public int ConfirmationCount { get; private set; }
+        public string LastConfirmationMessage { get; private set; } = "";
+
+        public ConfirmingMessageBoxService(bool confirm)
+        {
+            _confirm = confirm;
+        }
+
+        public Task ShowErrorAsync(string title, string message)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task ShowWarningAsync(string title, string message)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ConfirmWarningAsync(string title, string message, string confirmText = "OK", string cancelText = "Abbrechen")
+        {
+            ConfirmationCount++;
+            LastConfirmationMessage = message;
+            return Task.FromResult(_confirm);
+        }
     }
 }

--- a/tests/TheraPay.UI.Tests/PatientPanelViewModel_test.cs
+++ b/tests/TheraPay.UI.Tests/PatientPanelViewModel_test.cs
@@ -1,0 +1,78 @@
+namespace TheraPay.UI.Tests;
+
+using Microsoft.Extensions.DependencyInjection;
+using TheraPay.Core;
+using TheraPay.Domain;
+using TheraPay.UI.Navigation;
+using TheraPay.UI.ViewModels.Panels;
+
+public class PatientPanelViewModel_test
+{
+    [Fact]
+    public void GivenActiveAndInactivePatients_FilterActiveAndInactive_UsesPatientActivityStatus()
+    {
+        // GIVEN
+        var panel = CreatePanelWithActiveAndInactivePatients();
+
+        // WHEN
+        panel.FilterAll = true;
+
+        // THEN
+        Assert.Equal(2, panel.Patients.Count);
+
+        // WHEN
+        panel.FilterActive = true;
+
+        // THEN
+        var activePatient = Assert.Single(panel.Patients);
+        Assert.Equal("ACTIVE", activePatient.Id);
+
+        // WHEN
+        panel.FilterArchived = true;
+
+        // THEN
+        var inactivePatient = Assert.Single(panel.Patients);
+        Assert.Equal("INACTIVE", inactivePatient.Id);
+    }
+
+    [Fact]
+    public void GivenOnlyActivePatientsMode_PanelShowsOnlyActivePatientsAndHidesActivityFilter()
+    {
+        // GIVEN
+        var panel = CreatePanelWithActiveAndInactivePatients();
+
+        // WHEN
+        panel.ShowOnlyActivePatients = true;
+
+        // THEN
+        Assert.False(panel.ShowActivityFilter);
+        Assert.True(panel.FilterActive);
+        var activePatient = Assert.Single(panel.Patients);
+        Assert.Equal("ACTIVE", activePatient.Id);
+
+        // WHEN
+        panel.FilterAll = true;
+        panel.FilterArchived = true;
+
+        // THEN
+        Assert.False(panel.FilterAll);
+        Assert.False(panel.FilterArchived);
+        activePatient = Assert.Single(panel.Patients);
+        Assert.Equal("ACTIVE", activePatient.Id);
+    }
+
+    private static PatientPanelViewModel CreatePanelWithActiveAndInactivePatients()
+    {
+        var patientRepository = new InMemoryPatientRepository();
+        patientRepository.Add(new Patient("Ada", "Active", "ACTIVE"));
+
+        var inactivePatient = new Patient("Ida", "Inactive", "INACTIVE");
+        inactivePatient.IsActive = false;
+        patientRepository.Add(inactivePatient);
+
+        var patientService = new PatientService(patientRepository);
+        var navigationService = new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider());
+
+        return new PatientPanelViewModel(patientService, navigationService);
+    }
+}

--- a/tests/TheraPay.UI.Tests/PatientsViewModel_test.cs
+++ b/tests/TheraPay.UI.Tests/PatientsViewModel_test.cs
@@ -1,0 +1,67 @@
+namespace TheraPay.UI.Tests;
+
+using Microsoft.Extensions.DependencyInjection;
+using TheraPay.Core;
+using TheraPay.Domain;
+using TheraPay.UI.Navigation;
+using TheraPay.UI.State;
+using TheraPay.UI.ViewModels;
+
+public class PatientsViewModel_test
+{
+    [Fact]
+    public void GivenNewPatientView_PatientDataIsEditable()
+    {
+        // GIVEN
+        PatientsViewModel viewModel = CreateViewModel();
+
+        // THEN
+        Assert.False(viewModel.IsEditMode);
+        Assert.True(viewModel.IsPatientDataEditable);
+        Assert.True(viewModel.IsPatientIdEditable);
+    }
+
+    [Fact]
+    public void GivenExistingPatient_LoadPatientForEdit_DisablesPatientDataEditing()
+    {
+        // GIVEN
+        var patientRepository = new InMemoryPatientRepository();
+        patientRepository.Add(new Patient("Ada", "Lovelace", "AL1"));
+        PatientsViewModel viewModel = CreateViewModel(patientRepository);
+
+        // WHEN
+        viewModel.LoadPatientForEdit("AL1");
+
+        // THEN
+        Assert.True(viewModel.IsEditMode);
+        Assert.False(viewModel.IsPatientDataEditable);
+        Assert.False(viewModel.IsPatientIdEditable);
+        Assert.Equal("AL1", viewModel.PatientFields.PatientID);
+    }
+
+    [Fact]
+    public void GivenExistingPatient_WhenEditingEnabled_PatientIdStaysLocked()
+    {
+        // GIVEN
+        var patientRepository = new InMemoryPatientRepository();
+        patientRepository.Add(new Patient("Ada", "Lovelace", "AL1"));
+        PatientsViewModel viewModel = CreateViewModel(patientRepository);
+        viewModel.LoadPatientForEdit("AL1");
+
+        // WHEN
+        viewModel.IsPatientDataEditable = true;
+
+        // THEN
+        Assert.True(viewModel.IsPatientDataEditable);
+        Assert.False(viewModel.IsPatientIdEditable);
+    }
+
+    private static PatientsViewModel CreateViewModel(InMemoryPatientRepository? patientRepository = null)
+    {
+        patientRepository ??= new InMemoryPatientRepository();
+        var patientService = new PatientService(patientRepository);
+        var navigationService = new NavigationService(new NavigationStore(), new ServiceCollection().BuildServiceProvider());
+
+        return new PatientsViewModel(patientService, new ProjectSession(), navigationService);
+    }
+}


### PR DESCRIPTION
This branch add mainly soft delete functionality for the Patients.
-> They can be deleted and no longer used if deleted, but they are still present in the data, hence soft-delete. The deletion invalidates creating invoice drafts, but not editing issued invoices statuses. For deleted patients also no new appointments can be created.
-> At this point there is no recovery for deleted patients planned or desired. But ultimately within the database the deletion can be manually undeleted by changing the value from True to False. This is currently the only option for patient recovery after deleting it.

Additionally some minor changes have been implemented as well:
- patient editing requires additional checkbox to prevent accidental editing the data
- inactive/active status of patients is now connected and stored in the csv
- button position of editing and deleting patients has been moved
- invoice drafts can now be deleted as well